### PR TITLE
WEBCLIENT fixes:

### DIFF
--- a/IoT Firmware/olimex/include/user_webclient.h
+++ b/IoT Firmware/olimex/include/user_webclient.h
@@ -1,7 +1,7 @@
 #ifndef __USER_WEBCLIENT_H__
 	#define __USER_WEBCLIENT_H__
 	
-	#define WEBCLIENT_DEBUG                0
+	#define WEBCLIENT_DEBUG                1
 	#define WEBCLIENT_VERBOSE_OUTPUT       0
 	
 	#define WEBCLIENT_TIMEOUT              5000
@@ -17,6 +17,15 @@
 		UPGRADE,
 		WEBSOCKET
 	} webclient_state;
+	
+	/* State machine of receiving */
+	typedef enum {
+		WEBCLIENT_RESP_STATE_INIT = 0,
+		WEBCLIENT_RESP_STATE_WAIT,			// Request sent, waiting for response
+		WEBCLIENT_RESP_STATE_WAITCHUNK,		// Wating chunks if HTTP1.1: Transfer-Encoding: chunked (thingspeak.com response)
+		WEBCLIENT_RESP_STATE_OK,			// OK 200 (no retries)
+		WEBCLIENT_RESP_STATE_ERROR			// != 200 (response error)
+	} webclient_response_state;
 	
 	typedef struct _webclient_request_ {
 		bool ssl;
@@ -37,8 +46,10 @@
 		
 		webclient_state state;
 		
+		webclient_response_state response_state;	// status of receiving / received message(s)
 		uint8 retry;
 		uint32 retry_timer;
+		uint32 disconnect_timer;
 		
 		STAILQ_ENTRY(_webclient_request_) entries;
 	} webclient_request;


### PR DESCRIPTION
- request cleanup
- timer cleanup when cleaning request
- receiving chunked responses HTTP1.1 (eg. thingspeak.com does)
- timeout timer moved to the beginning of request-response handling to protect whole handshaking
