### PR TITLE
Hostname settable

### DIFF
--- a/IoT Firmware/app/index.html
+++ b/IoT Firmware/app/index.html
@@ -167,6 +167,7 @@
 				<label>SSID</label>             <input type="text"     name="SSID"        value=""  /> <br/>
 				<label>Password</label>         <input type="text"     name="Password"    value=""  /> <br/>
 				
+				<label>Hostname</label>         <input type="text"     name="Hostname"    value="" /> <br/>
 				<label>Autoconnect</label>      <input type="checkbox" name="AutoConnect" value="1" /> <br/>
 				<label>DHCP</label>             <input type="checkbox" name="DHCP"        value="1" /> <br/>
 				<fieldset name="IP">

--- a/IoT Firmware/olimex/include/user_config.h
+++ b/IoT Firmware/olimex/include/user_config.h
@@ -210,6 +210,7 @@
 	#define USER_CONFIG_EVENTS_SIZE          128
 	#define USER_CONFIG_PATH_SIZE            256
 	#define USER_CONFIG_TOKEN_SIZE            64
+	#define USER_CONFIG_HOSTNAME_SIZE         32
 	                                             
 	#define MAX_WIFI_STORED_AP_NUMBER          5
 	#define WIFI_STORED_AP_NUMBER              1

--- a/IoT Firmware/olimex/include/user_config.h
+++ b/IoT Firmware/olimex/include/user_config.h
@@ -280,6 +280,7 @@
 		char      events_path[USER_CONFIG_PATH_SIZE];
 		char      events_name[USER_CONFIG_USER_SIZE];
 		char      events_token[USER_CONFIG_TOKEN_SIZE];
+		char      station_hostname[USER_CONFIG_USER_SIZE];
 		
 		char      check[7];
 	} user_config;

--- a/IoT Firmware/olimex/user/user_config.c
+++ b/IoT Firmware/olimex/user/user_config.c
@@ -884,7 +884,7 @@ void ICACHE_FLASH_ATTR config_station_handler(
 					user_configuration.station.ip.gw.addr = ip4_addr_parse(gw);
 				} else if (jsonparse_strcmp_value(&parser, "Hostname") == 0) {
 					jsonparse_next(&parser);jsonparse_next(&parser);
-					jsonparse_copy_value(&parser, user_configuration.station_hostname, USER_CONFIG_USER_SIZE);
+					jsonparse_copy_value(&parser, user_configuration.station_hostname, USER_CONFIG_HOSTNAME_SIZE);
 				}
 
 			}


### PR DESCRIPTION
Station hostname was fixed to default string of var USER_CONFIG_DEFAULT_AP_SSID.
It is nice to be station hostname settable, since it is very possible to have more than one ESP-Olimex device in the same subnet network.
Check my pull request please.
Best regards MB
